### PR TITLE
Allow the specification of either RSS2 or ATOM to be used as the XML …

### DIFF
--- a/app/code/community/Aligent/Feeds/Model/Writer/Xml.php
+++ b/app/code/community/Aligent/Feeds/Model/Writer/Xml.php
@@ -2,12 +2,99 @@
 
 class Aligent_Feeds_Model_Writer_Xml extends Aligent_Feeds_Model_Writer_Abstract {
 
+    const XML_SPEC_ORIGINAL = 0;
+    const XML_SPEC_ATOM = 1;
+    const XML_SPEC_RSS2 = 2;
+
     protected $_vFileExtension = 'xml';
 
     /* @var XMLWriter $_oXmlWriter */
     protected $_oXmlWriter;
 
     protected $_aTagMap;
+
+    protected $_xmlSpecification = 0;
+
+    protected function _getOutputType() {
+        return $this->_xmlSpecification;
+    }
+
+    /**
+     * Set the XML specification from config.
+     *
+     * @param $oConfig
+     */
+    protected function _setXMLSpecification($oConfig) {
+        if (!isset($oConfig->specification)) {
+            $this->_xmlSpecification = self::XML_SPEC_ORIGINAL;
+        } else {
+            switch(strtolower($oConfig->specification)) {
+                case "atom":
+                    $this->_xmlSpecification = self::XML_SPEC_ATOM;
+                    break;
+                case "rss2":
+                    $this->_xmlSpecification = self::XML_SPEC_RSS2;
+                    break;
+                case self::XML_SPEC_ATOM:
+                    $this->_xmlSpecification = self::XML_SPEC_ATOM;
+                    break;
+                case self::XML_SPEC_RSS2:
+                    $this->_xmlSpecification = self::XML_SPEC_RSS2;
+                    break;
+                default:
+                    $this->_xmlSpecification = self::XML_SPEC_ORIGINAL;
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Add the opening document tags for the xml writer according to the specification being used.
+     * The default remains as it currently was which does not meet either specification.
+     */
+    protected function _openDocumentTags() {
+        switch($this->_getOutputType()) {
+            case self::XML_SPEC_ATOM:
+                $this->_oXmlWriter->startElement('feed');
+                $this->_oXmlWriter->writeAttribute('xmlns','http://www.w3.org/2005/Atom');
+                $this->_oXmlWriter->writeAttribute('xmlns:g','http://base.google.com/ns/1.0');
+
+                break;
+            case self::XML_SPEC_RSS2:
+                $this->_oXmlWriter->startElement('rss');
+                $this->_oXmlWriter->writeAttribute('version','2.0');
+                $this->_oXmlWriter->writeAttribute('xmlns:g','http://base.google.com/ns/1.0');
+
+                $this->_oXmlWriter->startElement('channel');
+                break;
+            default:
+                $this->_oXmlWriter->startElement('rss');
+                $this->_oXmlWriter->writeAttribute('version','2.0');
+                $this->_oXmlWriter->writeAttribute('xmlns:g','http://base.google.com/ns/1.0');
+
+                // Write Atom feed header for Google Shopping
+                $this->_oXmlWriter->startElement('feed');
+                break;
+        }
+    }
+
+    /**
+     * Add the opening product/item tag based on the xml specification.
+     */
+    protected function _openElementTags() {
+        switch($this->_getOutputType()) {
+            case self::XML_SPEC_ATOM:
+                $this->_oXmlWriter->startElement('entry');
+                break;
+            case self::XML_SPEC_RSS2:
+                $this->_oXmlWriter->startElement('item');
+                break;
+            default:
+                $this->_oXmlWriter->startElement('entry');
+                break;
+        }
+
+    }
 
     public function init($vStoreCode, $vFeedname, Mage_Core_Model_Config_Element $oConfig, Mage_Core_Model_Config_Element $oFields) {
         parent::init($vStoreCode, $vFeedname, $oConfig, $oFields);
@@ -17,19 +104,17 @@ class Aligent_Feeds_Model_Writer_Xml extends Aligent_Feeds_Model_Writer_Abstract
             return false;
         }
 
+        // Set output specification
+        $this->_setXMLSpecification($oConfig);
+
         // Open the output file
         $vFileName = $this->getFilename();
 
         $this->_oXmlWriter = new XMLWriter();
         $this->_oXmlWriter->openUri($vFileName);
 
-        //Write rss version
-        $this->_oXmlWriter->startElement('rss');
-        $this->_oXmlWriter->writeAttribute('version','2.0');
-        $this->_oXmlWriter->writeAttribute('xmlns:g','http://base.google.com/ns/1.0');
+        $this->_openDocumentTags();
 
-        // Write Atom feed header for Google Shopping
-        $this->_oXmlWriter->startElement('feed');
         $this->_oXmlWriter->writeElement('title', Mage::app($vStoreCode)->getDefaultStoreView()->getFrontendName());
         $this->_oXmlWriter->writeElement('link', Mage::app()->getStore($vStoreCode)->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK));
         $this->_oXmlWriter->writeElement('updated', date(DATE_ATOM));
@@ -69,7 +154,7 @@ class Aligent_Feeds_Model_Writer_Xml extends Aligent_Feeds_Model_Writer_Abstract
      * @return $this
      */
     function writeDataRow($aRow) {
-        $this->_oXmlWriter->startElement('entry');
+        $this->_openElementTags();
         foreach ($this->_aTagMap as $vIdx => $vTag) {
             if (array_key_exists($vIdx, $aRow)) {
                 if ($vTag == 'link') {


### PR DESCRIPTION
…output. By default neither will be used.

@michaelwylde can you please check if this is the only commit that is required.