### PR TITLE
Fix issue with installation where enterprise table not yet created

### DIFF
--- a/app/etc/modules/Aligent_Feeds.xml
+++ b/app/etc/modules/Aligent_Feeds.xml
@@ -4,6 +4,9 @@
         <Aligent_Feeds>
             <active>true</active>
             <codePool>community</codePool>
+            <depends>
+                <Enterprise_Index/>
+            </depends>
         </Aligent_Feeds>
     </modules>
 </config>


### PR DESCRIPTION
Considering this branch is name `1.13_url_fix`, assuming only enterprise projects using this branch